### PR TITLE
Add privilege dropping and basic Docker security hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,17 @@ pools:
 
 interfaces: [ eth1 ]
 leasedir: /var/lib/golang-dhcpd
+
+run_as_user: dhcp
+run_as_group: dhcp
 ```
 
 ### Running in Docker
 
     mkdir /etc/golang-dhcpd
     cp conf.yml /etc/golang-dhcpd/conf.yaml
-    docker build -t golang-dhcpd:latest .
-    docker-compose -f docker-compose.yml up
+    docker compose up --build -d
+    docker compose logs -f
 
 ### Example command output on VM acting as DHCP server
 
@@ -84,7 +87,8 @@ root@ubuntu2:~#
 
 ## Status
 
-- Verified to work with Alpine's `udhcpc` client, Ubuntu's `dhclient` client, and Windows 10.
+- Verified to work with Alpine's `udhcpc` client, Ubuntu's `dhclient` client,
+  Windows 10, LG WebOS, Android phones.
 - Relay requests verified to work with isc-dhcp-relay.
 
 ## Implemented

--- a/conf.go
+++ b/conf.go
@@ -89,6 +89,8 @@ type Conf struct {
 	Interfaces []string   `yaml:"interfaces"`
 	MaxConcurrentRequests int        `yaml:"max_concurrent_requests"`
 	RequestTimeoutSeconds int        `yaml:"request_timeout_seconds"`
+	RunAsUser             string     `yaml:"run_as_user"`
+	RunAsGroup            string     `yaml:"run_as_group"`
 }
 
 func ParseConf(path string) (*Conf, error) {

--- a/conf.yaml
+++ b/conf.yaml
@@ -29,5 +29,8 @@ pools:
 leasedir: .
 interfaces: [ eth1, eth2 ]
 
+run_as_user: dhcp
+run_as_group: dhcp
+
 # The following makes more sense
 #leasedir: /var/lib/golang-dhcpd

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,38 @@
 services:
 
   golang-dhcpd:
-    image: golang-dhcpd:latest
-    #build: .
+    #image: golang-dhcpd:latest
+    build: .
     command: ['/app/mygodhcpd', '-conf', '/etc/golang-dhcpd/conf.yaml']
     restart: always
     volumes:
-      - /etc/golang-dhcpd:/etc/golang-dhcpd
+      - /etc/golang-dhcpd:/etc/golang-dhcpd:ro
       #- /var/lib/golang-dhcpd:/var/lib/golang-dhcpd
     network_mode: "host"
     ports:
       - '67:67/udp'
     hostname: golang-dhcpd
+
+    # Security hardening
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
+      - SETUID
+      - SETGID
+    read_only: true
+    tmpfs:
+      - /tmp
+      - /var/lib/golang-dhcpd:noexec,nosuid,size=100m,uid=1001,gid=1001
+
+    # Resource limits
+    deploy:
+      resources:
+        limits:
+          memory: 64M
+          cpus: '0.5'
+        reservations:
+          memory: 16M
+          cpus: '0.1'

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module mygodhcpd
 
-go 1.23.4
+go 1.25.1
 
 require (
 	github.com/stretchr/testify v1.7.0

--- a/main.go
+++ b/main.go
@@ -57,6 +57,11 @@ func forkUnprivilegedWithSocket(ln *net.UDPConn, confPath, username, groupname s
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.ExtraFiles = []*os.File{file}
+	cmd.Env = []string{
+		"PATH=",
+		"HOME=/app",
+		fmt.Sprintf("USER=%s", username),
+	}
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Credential: &syscall.Credential{
 			Uid: uint32(uid),

--- a/main.go
+++ b/main.go
@@ -2,22 +2,76 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"net"
+	"os"
+	"os/exec"
+	"os/user"
+	"strconv"
 	"syscall"
 	"time"
 )
 
-func getConfPath() string {
+func getFlags() (string, bool) {
 	conf := flag.String("conf", "", "Path to configuration yaml file")
+	unprivileged := flag.Bool("unprivileged", false, "Run as unprivileged process with inherited socket")
 	flag.Parse()
-	return *conf
+	return *conf, *unprivileged
+}
+
+func setupSocket(ln *net.UDPConn) {
+	// Configure socket to receive additional OOB data with each incoming packet,
+	// which includes the ID of the incoming interface
+	file, err := ln.File()
+	if err != nil {
+		log.Fatalf("Failed getting socket descriptor: %v", err)
+	}
+	defer file.Close()
+
+	syscall.SetsockoptInt(int(file.Fd()), syscall.IPPROTO_IP, syscall.IP_PKTINFO, 1)
+	ln.SetReadBuffer(1048576)
+}
+
+func forkUnprivilegedWithSocket(ln *net.UDPConn, confPath, username, groupname string) error {
+	u, err := user.Lookup(username)
+	if err != nil {
+		return fmt.Errorf("user lookup failed: %w", err)
+	}
+
+	g, err := user.LookupGroup(groupname)
+	if err != nil {
+		return fmt.Errorf("group lookup failed: %w", err)
+	}
+
+	uid, _ := strconv.Atoi(u.Uid)
+	gid, _ := strconv.Atoi(g.Gid)
+
+	file, err := ln.File()
+	if err != nil {
+		return fmt.Errorf("failed to get socket file: %w", err)
+	}
+	defer file.Close()
+
+	cmd := exec.Command(os.Args[0], "-conf", confPath, "-unprivileged")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.ExtraFiles = []*os.File{file}
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Credential: &syscall.Credential{
+			Uid: uint32(uid),
+			Gid: uint32(gid),
+		},
+	}
+
+	log.Printf("Starting unprivileged process as %s:%s", username, groupname)
+	return cmd.Run()
 }
 
 func main() {
 	var err error
 
-	confPath := getConfPath()
+	confPath, unprivileged := getFlags()
 
 	if confPath == "" {
 		log.Fatalf("Configuration file path not given")
@@ -28,6 +82,44 @@ func main() {
 		log.Fatalf("Failed parsing conf: %v", err)
 	}
 
+	var ln *net.UDPConn
+
+	// Check if we're the unprivileged child process with inherited socket
+	if unprivileged {
+		// Restore socket from file descriptor 3 (first ExtraFile)
+		file := os.NewFile(3, "socket")
+		conn, err := net.FileConn(file)
+		if err != nil {
+			log.Fatalf("Failed to restore socket from fd: %v", err)
+		}
+		ln = conn.(*net.UDPConn)
+		file.Close() // Close the file, keep the connection
+	} else {
+		// We're the privileged parent process
+		addr := net.UDPAddr{
+			Port: 67,
+			IP:   net.ParseIP("0.0.0.0"),
+		}
+
+		ln, err = net.ListenUDP("udp", &addr)
+		if err != nil {
+			log.Fatalf("Failed listening: %v", err)
+		}
+
+		// If we need to drop privileges, fork to unprivileged process
+		if os.Getuid() == 0 && conf.RunAsUser != "" {
+			err := forkUnprivilegedWithSocket(ln, confPath, conf.RunAsUser, conf.RunAsGroup)
+			if err != nil {
+				log.Fatalf("Failed to fork unprivileged: %v", err)
+			}
+			return // Parent process exits
+		}
+	}
+
+	defer ln.Close()
+
+	setupSocket(ln)
+
 	app := NewApp()
 
 	err = app.InitConf(conf)
@@ -35,28 +127,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed initializing: %v", err)
 	}
-
-	addr := net.UDPAddr{
-		Port: 67,
-		IP:   net.ParseIP("0.0.0.0"),
-	}
-
-	ln, err := net.ListenUDP("udp", &addr)
-	if err != nil {
-		log.Fatalf("Failed listening: %v", err)
-	}
-	defer ln.Close()
-
-	// Boilerplate to get additional OOB data with each incoming packet, which
-	// includes the ID of the incoming interface
-	file, err := ln.File()
-	if err != nil {
-		log.Fatalf("Failed getting socket descriptor: %v", err)
-	}
-
-	syscall.SetsockoptInt(int(file.Fd()), syscall.IPPROTO_IP, syscall.IP_PKTINFO, 1)
-
-	ln.SetReadBuffer(1048576)
 
 	buf := make([]byte, 1024)
 	oob := make([]byte, 1024)


### PR DESCRIPTION
* Implement exec-based privilege dropping from root to unprivileged user
* Add configuration run_as_user and run_as_group
* Add multi-stage Docker build with static binary
* Add basic Docker compose security: minimal capabilities,
   read-only filesystem, resource limits
* Update Go to 1.25.1