### PR TITLE
Update docker and docker compose to run dhcpd with unprivileged user

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,16 @@ leasedir: /var/lib/golang-dhcpd
 
     mkdir /etc/golang-dhcpd
     cp conf.yml /etc/golang-dhcpd/conf.yaml
-    docker build -t golang-dhcpd:latest .
-    docker-compose -f docker-compose.yml up
+    docker compose up --build -d
+    docker compose logs -f
+
+**Note:** The Docker setup uses ipvlan networking for security. Update your config to:
+- Set `interfaces: [ eth0 ]` (interface name inside container may not be the same as host interface)
+- Set `myip:` to match the container's IP address
+
+**Warning:** Using `network_mode: "host"` with unprivileged users may fail
+to bind to port 67 due to Docker limitations with capabilities in host networking mode,
+so one can either use `ipvlan` mode with dhcp user or `host` mode with root user.
 
 ### Example command output on VM acting as DHCP server
 
@@ -84,7 +92,8 @@ root@ubuntu2:~#
 
 ## Status
 
-- Verified to work with Alpine's `udhcpc` client, Ubuntu's `dhclient` client, and Windows 10.
+- Verified to work with Alpine's `udhcpc` client, Ubuntu's `dhclient` client,
+  Windows 10, LG WebOS, Android phones.
 - Relay requests verified to work with isc-dhcp-relay.
 
 ## Implemented

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,48 @@
 services:
 
   golang-dhcpd:
-    image: golang-dhcpd:latest
-    #build: .
+    #image: golang-dhcpd:latest
+    build: .
+    user: "1001:1001"  # Run as dhcp user
     command: ['/app/mygodhcpd', '-conf', '/etc/golang-dhcpd/conf.yaml']
     restart: always
     volumes:
-      - /etc/golang-dhcpd:/etc/golang-dhcpd
+      - /etc/golang-dhcpd:/etc/golang-dhcpd:ro
       #- /var/lib/golang-dhcpd:/var/lib/golang-dhcpd
-    network_mode: "host"
-    ports:
-      - '67:67/udp'
+    networks:
+      dhcp_net:
+        ipv4_address: 192.168.0.2
     hostname: golang-dhcpd
+
+    # Security hardening
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
+    read_only: true
+    tmpfs:
+      - /tmp
+      - /var/lib/golang-dhcpd:noexec,nosuid,size=100m,uid=1001,gid=1001
+
+    # Resource limits
+    deploy:
+      resources:
+        limits:
+          memory: 64M
+          cpus: '0.5'
+        reservations:
+          memory: 16M
+          cpus: '0.1'
+
+networks:
+  dhcp_net:
+    driver: ipvlan
+    driver_opts:
+      parent: eth1  # Replace with your host interface name
+      ipvlan_mode: l2
+    ipam:
+      config:
+        - subnet: 192.168.0.0/24
+          gateway: 192.168.0.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module mygodhcpd
 
-go 1.23.4
+go 1.25.1
 
 require (
 	github.com/stretchr/testify v1.7.0


### PR DESCRIPTION
* Add multi-stage Docker build with dhcp user (UID 1001)
* Replace network_mode: host with ipvlan networking for better security
* Add basic Docker security hardening (capabilities, read-only, resource limits)
* Upgrade Go to 1.25.1